### PR TITLE
Use LevelDict for level operations

### DIFF
--- a/camera_editor.py
+++ b/camera_editor.py
@@ -1,0 +1,49 @@
+"""Camera editor utilities using adofaipy.LevelDict."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple, Dict, Any
+import math
+import adofaipy
+
+
+class CameraEditor:
+    """Load and modify MoveCamera events in an ADOFAI level."""
+
+    def __init__(self, adofai_path: Path | str) -> None:
+        # Load level using LevelDict instead of adofaipy.load
+        self.level = adofaipy.LevelDict(str(adofai_path))
+        # Store existing MoveCamera actions
+        self.camera_actions: List[Dict[str, Any]] = [
+            dict(action)
+            for action in self.level.getActions(lambda a: a["eventType"] == "MoveCamera")
+        ]
+
+    # --- Tile position helpers -------------------------------------------------
+    def tile_positions(self) -> List[Tuple[float, float]]:
+        """Return cartesian positions for each tile based on angles.
+
+        The final tile in ``LevelDict.tiles`` duplicates the last angle, so it
+        is ignored when computing the path."""
+        x, y = 0.0, 0.0
+        positions = [(x, y)]
+        for tile in self.level.tiles[:-1]:
+            rad = math.radians(tile.angle)
+            x += math.cos(rad)
+            y += math.sin(rad)
+            positions.append((x, y))
+        return positions
+
+    # --- Save logic ------------------------------------------------------------
+    def save(self, out_path: Path | str) -> None:
+        """Write the current level to ``out_path``.
+
+        Existing MoveCamera actions are removed and then re-added from
+        ``self.camera_actions`` prior to writing."""
+        # Remove any existing MoveCamera events
+        self.level.removeActions(lambda a: a["eventType"] == "MoveCamera")
+        # Rebuild from stored actions
+        for action in self.camera_actions:
+            self.level.addAction(adofaipy.Action(action))
+        # Export to file
+        self.level.writeToFile(str(out_path))


### PR DESCRIPTION
## Summary
- Load levels with `adofaipy.LevelDict` and extract MoveCamera events
- Add tile position helper and save using LevelDict's APIs

## Testing
- `python - <<'PY'
from pathlib import Path
import adofaipy
from camera_editor import CameraEditor

# Build a sample level
lvl = adofaipy.LevelDict()
lvl.appendTile(90)
lvl.appendTile(180)
lvl.addAction(adofaipy.Action({'floor': 1, 'eventType': 'MoveCamera', 'duration': 1.0, 'position': [1.0, 2.0]}))
in_path = Path('sample.adofai')
lvl.writeToFile(str(in_path))
editor = CameraEditor(in_path)
orig_positions = editor.tile_positions()
orig_actions = editor.camera_actions.copy()
out_path = Path('sample_out.adofai')
editor.save(out_path)
editor2 = CameraEditor(out_path)
assert editor2.tile_positions() == orig_positions
assert editor2.camera_actions == orig_actions
print('positions', editor2.tile_positions())
print('actions', editor2.camera_actions)
PY`

------
https://chatgpt.com/codex/tasks/task_e_688e2e2a903483259f0c35f49595d2e7