### PR TITLE
Add custom easing support and simple level loader

### DIFF
--- a/level.py
+++ b/level.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass
+class Level:
+    """Minimal representation of an ADOFAI level used by the editor.
+
+    Only the parts of the file that are required by the camera editor are
+    stored: ``pathData`` describing the tile layout, ``settings`` for timing
+    information and ``actions`` containing event data.
+    """
+
+    pathData: str
+    settings: Dict[str, Any]
+    actions: List[Dict[str, Any]]
+
+    @classmethod
+    def load(cls, path: str | Path) -> "Level":
+        """Load a level from ``path``."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(
+            pathData=data.get("pathData", ""),
+            settings=data.get("settings", {}),
+            actions=data.get("actions", []),
+        )
+
+    def dict(self) -> Dict[str, Any]:
+        """Return the level as a plain dictionary suitable for ``json``."""
+        return {
+            "pathData": self.pathData,
+            "settings": self.settings,
+            "actions": self.actions,
+        }


### PR DESCRIPTION
## Summary
- Add a minimal `Level` dataclass for reading and writing ADOFAI maps
- Track and render custom easing curves per keyframe, storing results in `customEase`
- Replace `adofaipy` dependency with the new loader and use pre-rendered curves during interpolation

## Testing
- `python -m py_compile camera_editor.py easing.py level.py`


------
https://chatgpt.com/codex/tasks/task_e_688e3a05a750832593a2ece5e6d9eab0