### PR TITLE
Add custom easing support and timeline improvements

### DIFF
--- a/easing.py
+++ b/easing.py
@@ -217,6 +217,39 @@ def elastic(t: float, params: ElasticParams = ElasticParams()) -> float:
     decay_term = math.exp(-params.decay * t)
     return 1 - (sin_term * decay_term)
 
+
+def cubic_bezier(p1x: float, p1y: float, p2x: float, p2y: float) -> Callable[[float], float]:
+    """Return a cubic bezier easing function defined by control points."""
+
+    def func(t: float) -> float:
+        # Invert x(t) using Newton-Raphson iterations
+        u = t
+        for _ in range(5):
+            x = (
+                (1 - u) ** 3 * 0
+                + 3 * (1 - u) ** 2 * u * p1x
+                + 3 * (1 - u) * u ** 2 * p2x
+                + u ** 3
+            )
+            dx = (
+                3 * (1 - u) ** 2 * (p1x - 0)
+                + 6 * (1 - u) * u * (p2x - p1x)
+                + 3 * u ** 2 * (1 - p2x)
+            )
+            if dx == 0:
+                break
+            u -= (x - t) / dx
+            u = max(0.0, min(1.0, u))
+        y = (
+            (1 - u) ** 3 * 0
+            + 3 * (1 - u) ** 2 * u * p1y
+            + 3 * (1 - u) * u ** 2 * p2y
+            + u ** 3
+        )
+        return y
+
+    return func
+
 # Registry of easing functions for easy selection
 EASING_FUNCTIONS: dict[str, Callable[[float], float]] = {
     "Linear": linear,


### PR DESCRIPTION
## Summary
- Add a minimal `Level` dataclass for reading and writing ADOFAI maps
- Track and render custom easing curves per keyframe, storing results in `customEase`
- Replace `adofaipy` dependency with the new loader and use pre-rendered curves during interpolation
- Support drawing cubic Bezier easing curves in the GUI and export them per-frame so ADOFAI can reproduce the graph
- Introduce a color-coded multi-parameter timeline with draggable scrubber and playback camera indicator

## Testing
- `python -m py_compile camera_editor.py easing.py`

------
https://chatgpt.com/codex/tasks/task_e_688e3a05a750832593a2ece5e6d9eab0