### PR TITLE
Integrate adofaipy and enhance camera easing

### DIFF
--- a/easing.py
+++ b/easing.py
@@ -197,6 +197,10 @@ def ease_in_out_bounce(t: float, params: BounceParams = BounceParams()) -> float
 class ElasticParams:
     oscillations: int = 3
     decay: float = 3.0
+    # Additional phase shift parameter allowing the curve to start at a
+    # different point of the oscillation cycle.  This gives creators more
+    # freedom to fine tune the feel of the easing.
+    phase: float = 0.0
 
 
 def elastic(t: float, params: ElasticParams = ElasticParams()) -> float:
@@ -213,7 +217,7 @@ def elastic(t: float, params: ElasticParams = ElasticParams()) -> float:
     if t == 0 or t == 1:
         return t
     # Exponential decay multiplied by an oscillating sine component
-    sin_term = math.sin(params.oscillations * 2 * math.pi * t)
+    sin_term = math.sin(params.oscillations * 2 * math.pi * t + params.phase)
     decay_term = math.exp(-params.decay * t)
     return 1 - (sin_term * decay_term)
 

--- a/level.py
+++ b/level.py
@@ -1,0 +1,93 @@
+"""Lightweight wrapper around :mod:`adofaipy` for loading and saving levels.
+
+The original project expected a small ``Level`` helper providing ``load`` and
+``dict`` methods.  The previous repository did not include an implementation
+and performed JSON parsing manually.  This module re-introduces that helper but
+delegates all parsing and serialisation to the `adofaipy` package as requested
+by the user instructions.
+
+Only a tiny subset of the full API is implemented – enough for the camera
+editor to query settings, actions and path data and to write the modified level
+back to disk.  The heavy lifting of validating and writing the ``.adofai`` file
+is handled by :class:`adofaipy.LevelDict`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+from adofaipy import LevelDict
+
+
+@dataclass
+class Level:
+    """Container for an ADOFAI level using :mod:`adofaipy` under the hood."""
+
+    data: Dict[str, Any]
+    path: Path | None = None
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def load(cls, filename: Path) -> "Level":
+        """Parse ``filename`` using :mod:`adofaipy` and return a :class:`Level`.
+
+        Parameters
+        ----------
+        filename:
+            Path to the ``.adofai`` file.
+        """
+
+        ld = LevelDict(str(filename))
+        data = ld._getFileDict()  # type: ignore[attr-defined]
+        if "pathData" not in data and "angleData" in data:
+            # ``LevelDict`` exposes ``angleData`` when the file does not contain
+            # ``pathData``.  For the purposes of the editor we fall back to that
+            # so existing files continue to load correctly.
+            data["pathData"] = data.get("angleData", [])
+        return cls(data=data, path=Path(filename))
+
+    # ------------------------------------------------------------------
+    # Accessors used by the editor
+    # ------------------------------------------------------------------
+    @property
+    def actions(self) -> List[Dict[str, Any]]:
+        return self.data.setdefault("actions", [])
+
+    @actions.setter
+    def actions(self, value: List[Dict[str, Any]]) -> None:
+        self.data["actions"] = value
+
+    @property
+    def settings(self) -> Dict[str, Any]:
+        return self.data.setdefault("settings", {})
+
+    @property
+    def pathData(self) -> List[Any]:
+        return self.data.get("pathData", [])
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+    def dict(self) -> Dict[str, Any]:
+        """Return the internal dictionary representation."""
+
+        return self.data
+
+    def write(self, filename: Path | None = None) -> None:
+        """Write the level to ``filename`` using :mod:`adofaipy`.
+
+        If ``filename`` is ``None`` the path supplied to :meth:`load` is used.
+        """
+
+        dest = filename or self.path
+        if dest is None:
+            raise ValueError("No filename supplied for Level.write")
+        # ``LevelDict`` exposes a private helper for writing dictionaries.  We
+        # create a temporary instance and delegate the heavy lifting to it.
+        tmp = LevelDict("", encoding="utf-8")
+        tmp._writeDictToFile(self.data, str(dest))  # type: ignore[attr-defined]
+


### PR DESCRIPTION
## Summary
- Use adofaipy via a new `Level` wrapper to load and save levels
- Support layered camera offsets and persist them when saving
- Add a phase parameter to elastic easing with real-time UI control

## Testing
- `python -m py_compile camera_editor.py easing.py level.py`


------
https://chatgpt.com/codex/tasks/task_e_688f78fb317483259d96e78f8b0d162d